### PR TITLE
Force tcp transport argument to ffmpeg

### DIFF
--- a/src/helpers/recorder.js
+++ b/src/helpers/recorder.js
@@ -64,7 +64,7 @@ const RTSPRecorder = class {
   }
 
   getChildProcess(fileName) {
-    var args = ['-i', this.url]
+    var args = ['-rtsp_transport','tcp','-i', this.url]
     const mediaArgs = this.getArguments()
     mediaArgs.forEach((item) => {
       args.push(item)


### PR DESCRIPTION
Fixes an issue where video created by ffmpeg is corrupted due to lack of specific arguments.

https://github.com/sahilchaddha/homebridge-dafang/issues/17