### PR TITLE
Modified Recorder constructor to accept optional audioCodec

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ Records RTSP Audio/Visual Streams to local disk using ffmpeg
     }, 300000)
 ```
 
+
+> If your camera generates empty .mp4 files when recording, you might need to update its audio codec by passing in one usable by your camera (e.g., `aac`) in the Recorder's constructor. For example:
+
+
+```js
+  var rec = new Recorder({
+    url: 'rtsp://192.168.1.12:8554/unicast',
+        timeLimit: 60, // time in seconds for each segmented video file
+        folder: '/Users/sahilchaddha/Sahil/Projects/Github/node-rtsp-recorder/videos',
+        name: 'cam1',
+        audioCodec: 'aac'
+  })
+```
+
 ## Recording Audio 
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rtsp-recorder",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rtsp-recorder",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "RTSP Stream Recorder",
   "main": "src/index.js",
   "scripts": {

--- a/src/helpers/recorder.js
+++ b/src/helpers/recorder.js
@@ -22,6 +22,7 @@ const RTSPRecorder = class {
     this.categoryType = config.type || 'video'
     this.directoryPathFormat = config.directoryPathFormat || 'MMM-Do-YY'
     this.fileNameFormat = config.fileNameFormat || 'YYYY-M-D-h-mm-ss'
+    this.audioCodec = config.audioCodec || 'copy'
     fh.createDirIfNotExists(this.getDirectoryPath())
     fh.createDirIfNotExists(this.getTodayPath())
   }
@@ -60,7 +61,7 @@ const RTSPRecorder = class {
     if (this.categoryType === 'image') {
       return ['-vframes', '1']
     }
-    return ['-acodec', 'copy', '-vcodec', 'copy']
+    return ['-acodec', this.audioCodec, '-vcodec', 'copy']
   }
 
   getChildProcess(fileName) {


### PR DESCRIPTION
Added an optional `audioCodec` member to the Recorder constructor. In some cameras, an audio codec of `copy` was causing the generation of multiple empty .mp4 files. Allowing overrides lets these cameras function normally.